### PR TITLE
fix: fix error "Cannot read property 'length' of null" when Content-D…

### DIFF
--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -220,7 +220,7 @@ function eventClick(element, binding, pluginOptions) {
       let fileName = href.substring(href.lastIndexOf("/") + 1)
       if (contentDisposition) {
         const fileNameMatch = contentDisposition.match(/filename="(.+)"/)
-        if (fileNameMatch.length === 2) fileName = fileNameMatch[1]
+        if (fileNameMatch != null && fileNameMatch.length === 2) fileName = fileNameMatch[1]
       }
       link.setAttribute("download", fileName)
       document.body.appendChild(link)


### PR DESCRIPTION
…isposition header is not well formed

Some framework like .Net Core 2 populate Content-Disposition HTTP header in a way that is not RFC6266 compliant.
For example:
`Content-Disposition: attachment; filename=myReport.pdf`
Instead of (escape the filename with "):
`Content-Disposition: attachment; filename="myReport.pdf"`
This produce a "Cannot read property 'length' of null" since
`contentDisposition.match(/filename="(.+)"/)`
return null